### PR TITLE
Optionally accept Coveralls repository token on CLI

### DIFF
--- a/src/HpcCoverallsCmdLine.hs
+++ b/src/HpcCoverallsCmdLine.hs
@@ -11,6 +11,7 @@ import Trace.Hpc.Coveralls.Types
 data HpcCoverallsArgs = CmdMain
     { excludeDirs   :: [String]
     , testSuites    :: [String]
+    , repoToken     :: Maybe String
     , displayReport :: Bool
     , printResponse :: Bool
     , dontSend      :: Bool
@@ -19,11 +20,12 @@ data HpcCoverallsArgs = CmdMain
 
 hpcCoverallsArgs :: HpcCoverallsArgs
 hpcCoverallsArgs = CmdMain
-    { excludeDirs   = []                &= explicit &= typDir     &= name "exclude-dir"    &= help "Exclude sources files under the matching directory from the coverage report"
-    , displayReport = False             &= explicit               &= name "display-report" &= help "Display the json code coverage report that will be sent to coveralls.io"
-    , printResponse = False             &= explicit               &= name "print-response" &= help "Prints the json reponse received from coveralls.io"
-    , dontSend      = False             &= explicit               &= name "dont-send"      &= help "Do not send the report to coveralls.io"
-    , coverageMode  = AllowPartialLines &= explicit &= typ "MODE" &= name "coverage-mode"  &= help "Coverage conversion mode: AllowPartialLines (default), StrictlyFullLines"
+    { excludeDirs   = []                &= explicit &= typDir      &= name "exclude-dir"    &= help "Exclude sources files under the matching directory from the coverage report"
+    , displayReport = False             &= explicit                &= name "display-report" &= help "Display the json code coverage report that will be sent to coveralls.io"
+    , printResponse = False             &= explicit                &= name "print-response" &= help "Prints the json reponse received from coveralls.io"
+    , dontSend      = False             &= explicit                &= name "dont-send"      &= help "Do not send the report to coveralls.io"
+    , coverageMode  = AllowPartialLines &= explicit &= typ "MODE"  &= name "coverage-mode"  &= help "Coverage conversion mode: AllowPartialLines (default), StrictlyFullLines"
+    , repoToken     = Nothing           &= explicit &= typ "TOKEN" &= name "repo-token"     &= help "Coveralls repo token"
     , testSuites    = []                &= typ "TEST-SUITE" &= args
     } &= summary ("hpc-coveralls-" ++ versionString version ++ ", (C) Guillaume Nargeot 2014-2015")
       &= program "hpc-coveralls"

--- a/src/HpcCoverallsMain.hs
+++ b/src/HpcCoverallsMain.hs
@@ -38,7 +38,7 @@ writeJson :: String -> Value -> IO ()
 writeJson filePath = BSL.writeFile filePath . encode
 
 getConfig :: HpcCoverallsArgs -> Maybe Config
-getConfig hca = Config (excludeDirs hca) (coverageMode hca) <$> listToMaybe (testSuites hca)
+getConfig hca = Config (excludeDirs hca) (coverageMode hca) (repoToken hca) <$> listToMaybe (testSuites hca)
 
 main :: IO ()
 main = do

--- a/src/Trace/Hpc/Coveralls/Config.hs
+++ b/src/Trace/Hpc/Coveralls/Config.hs
@@ -5,5 +5,6 @@ import Trace.Hpc.Coveralls.Types (CoverageMode)
 data Config = Config {
     excludedDirs :: ![FilePath],
     coverageMode :: !CoverageMode,
+    repoToken    :: !(Maybe String),
     testSuites   :: ![String]
     }


### PR DESCRIPTION
(Appears to be) required for non-Travis CIs, or at least on CircleCI. Doesn't appear to break anything on Travis.