### PR TITLE
List Paths_hpc_coveralls in other-modules

### DIFF
--- a/hpc-coveralls.cabal
+++ b/hpc-coveralls.cabal
@@ -49,6 +49,7 @@ library
     Trace.Hpc.Coveralls.Util
   other-modules:
     HpcCoverallsCmdLine,
+    Paths_hpc_coveralls,
     Trace.Hpc.Coveralls.Cabal,
     Trace.Hpc.Coveralls.Config,
     Trace.Hpc.Coveralls.Curl,


### PR DESCRIPTION
Not doing so causes the linker to get confused when `hpc-coveralls` is configured with `--enable-executable-dynamic`. This was also discovered in https://github.com/fpco/stackage/issues/1338.

Fixes #52.