### PR TITLE
Allow specifying the HPC data directory explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,40 @@ You will have to specify it for example when using Travis-pro as in the example 
 --service-name=travis-pro
 ```
 
+#### --hpc-dir
+
+This option allows you to manually specify the hpc data directory to use. The behaviour without this option is to attempt to find the hpc directory in the typical places in the current directory.
+```bash
+--hpc-dir=/dir/share/hpc
+```
+
+This directory should contain your hpc data (mix files and tix files) in the standard directory structure for hpc output, for example:
+
+```bash
+hpc
+├── mix
+│   ├── my-lib-0.1.0.0
+│   │   └── my-lib-0.1.0.0-inplace
+│   │       ├── My.Lib.A.mix
+│   │       ├── My.Lib.B.mix
+│   |       └── My.Lib.C.mix
+│   ├── my-lib-test
+│   │   ├── SomeSpec.mix
+│   │   ├── SomeOtherSpec.mix
+│       └── Main.mix
+│   └── my-lib-test2
+│       ├── SomeSpec2.mix
+│       ├── SomeOtherSpec2.mix
+│       └── Main.mix
+└── tix
+    ├── my-lib-0.1.0.0
+    │   └── my-lib-0.1.0.0.tix
+    ├── my-lib-test
+    │   └── my-lib-test.tix
+    └── my-lib-test2
+        └── my-lib-test2.tix
+```
+
 # Limitations
 
 Because of the way hpc works, coverage data is only generated for modules that are referenced directly or indirectly by the test suites.

--- a/src/HpcCoverallsCmdLine.hs
+++ b/src/HpcCoverallsCmdLine.hs
@@ -18,6 +18,7 @@ data HpcCoverallsArgs = CmdMain
     , optCurlVerbose   :: Bool
     , optDontSend      :: Bool
     , optCoverageMode  :: CoverageMode
+    , optHpcDir        :: Maybe String
     } deriving (Data, Show, Typeable)
 
 hpcCoverallsArgs :: HpcCoverallsArgs
@@ -30,6 +31,7 @@ hpcCoverallsArgs = CmdMain
     , optCabalFile     = Nothing           &= explicit &= typ "FILE"  &= name "cabal-file"     &= help "Cabal file (ex.: module-name.cabal)"
     , optServiceName   = Nothing           &= explicit &= typ "TOKEN" &= name "service-name"   &= help "service-name (e.g. travis-pro)"
     , optRepoToken     = Nothing           &= explicit &= typ "TOKEN" &= name "repo-token"     &= help "Coveralls repo token"
+    , optHpcDir        = Nothing           &= explicit &= typDir      &= name "hpc-dir"        &= help "Explicitly use this hpc directory instead of trying to discover one"
     , argTestSuites    = []                &= typ "TEST-SUITES" &= args
     } &= summary ("hpc-coveralls v" ++ versionString version ++ ", (C) Guillaume Nargeot 2014-2015")
       &= program "hpc-coveralls"

--- a/src/HpcCoverallsMain.hs
+++ b/src/HpcCoverallsMain.hs
@@ -46,6 +46,7 @@ getConfig hca = Config
     (optCabalFile hca)
     (optServiceName hca)
     (optRepoToken hca)
+    (optHpcDir hca)
     <$> listToMaybe (argTestSuites hca)
 
 main :: IO ()

--- a/src/Trace/Hpc/Coveralls/Cabal.hs
+++ b/src/Trace/Hpc/Coveralls/Cabal.hs
@@ -23,11 +23,16 @@ import System.Directory
 
 getCabalFile :: FilePath -> IO (Maybe FilePath)
 getCabalFile dir = do
-    files <- (filter isCabal <$> getDirectoryContents dir) >>= filterM doesFileExist
-    case files of
-        [file] -> return $ Just file
-        _ -> return Nothing
-    where isCabal filename = ".cabal" `isSuffixOf` filename && length filename > 6
+    cabalFilesInDir <- filter isCabal <$> getDirectoryContents dir
+    cabalFiles <- filterM doesFileExist (mkFullPath <$> cabalFilesInDir)
+    case cabalFiles of
+        [file] -> do
+          return $ Just file
+        _ -> do
+          return Nothing
+    where
+      isCabal filename = ".cabal" `isSuffixOf` filename && length filename > 6
+      mkFullPath = ((dir <> "/") <>)
 
 getPackageNameVersion :: FilePath -> IO (Maybe String)
 getPackageNameVersion file = do

--- a/src/Trace/Hpc/Coveralls/Config.hs
+++ b/src/Trace/Hpc/Coveralls/Config.hs
@@ -3,10 +3,11 @@ module Trace.Hpc.Coveralls.Config where
 import Trace.Hpc.Coveralls.Types (CoverageMode)
 
 data Config = Config {
-    excludedDirs :: ![FilePath],
-    coverageMode :: !CoverageMode,
-    cabalFile    :: !(Maybe FilePath),
-    serviceName  :: !(Maybe String),
-    repoToken    :: !(Maybe String),
-    testSuites   :: ![String]
+    excludedDirs   :: ![FilePath],
+    coverageMode   :: !CoverageMode,
+    cabalFile      :: !(Maybe FilePath),
+    serviceName    :: !(Maybe String),
+    repoToken      :: !(Maybe String),
+    hpcDirOverride :: !(Maybe String),
+    testSuites     :: ![String]
     }


### PR DESCRIPTION
- Add functionality required to allow the user to specify the hpc data
  directory explicitly, rather than searching for it in the usual
  places. This is primarily motivated by the Nix package manager,
  where hpc output is usally written to some folder outside of the
  current directory (e.g. to
  /nix/store/HASH-my-lib-0.1.0.0/share/hpc).